### PR TITLE
Add link to Sc-advanced module in workshop materials

### DIFF
--- a/workshop/workshop-materials.md
+++ b/workshop/workshop-materials.md
@@ -13,7 +13,7 @@ PDF versions of the slides we present in this workshop can be found in the [slid
 
 ### Module Structure
 
-All materials for this workshop can be found in the `training-modules` repository within the [scRNA-seq-advanced](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/scRNA-seq-advanced) folder.
+All materials for this workshop can be found in the `training-modules` repository within the [`scRNA-seq-advanced`](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/scRNA-seq-advanced) folder.
 This folder includes both instruction notebooks we will walk through during the workshop and exercise notebooks to be used for practice (denoted by the `exercise` prefix).
 
 In this folder, you will notice that there may be two or three versions of some notebook files.
@@ -24,7 +24,7 @@ For example, there may be a `02-celltype_assignment-live.Rmd`, a `02-celltype_as
 - The `.nb.html` version of the file is a rendered web page of the notebook.
 This file can be downloaded or viewed via the links in the README file that you will see at the bottom of the file listing for each module.
 
-This workshop builds on material found in the [scRNA-seq] folder, which may be a helpful reference.
+This workshop builds on material found in the [`scRNA-seq`](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/scRNA-seq) folder, which may be a helpful reference.
 
 ### RStudio Server
 


### PR DESCRIPTION
Closes #11 

Here I updated the `workshop-materials.md` page to include the link to the `scRNA-seq-advanced` module. I believe that was everything that needed to be updated based on the issue? 

The other thing I did think about when updating this was if we wanted to update the image that is currently there since it shows files that are in the intro module that we won't be using. But updating that would require adding a new image to `training-modules` first and I don't know if that's entirely necessary until someone tells me we need to do it. 

Am I missing anything else to get that issue closed? 