### PR TITLE
Revise home page for this workshop specifically

### DIFF
--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -1,49 +1,35 @@
 ---
-title: Data Lab Virtual Training
+title: 2023 January Advanced Single-cell Training Workshop
 nav_title: Home
 permalink: /
 ---
 
 
 <img style = "padding: 0px 15px; float: right;" img src = "workshop/screenshots/CCDL_2021_Logo-x-ALSF_RGB.png" width = "300">
-The **[Childhood Cancer Data Lab (Data Lab)](https://www.ccdatalab.org/)** develops tools and training programs to empower childhood cancer researchers to utilize  data to make more robust discoveries.
+The **[Childhood Cancer Data Lab (Data Lab)](https://www.ccdatalab.org/)** develops tools and training programs to empower childhood cancer researchers to utilize data to make more robust discoveries.
 The Childhood Cancer Data Lab is an initiative of **[Alex's Lemonade Stand Foundation](https://www.alexslemonade.org/)**.
 
 ## {{site.training_title}}
 
 Dates: {{site.start_date}} through {{site.end_date}}
 
-## Getting Started
-
-
-### Pre-workshop Prep
+## Pre-workshop Prep
 
 * Please review the [Code of Conduct](../code-of-conduct.md).
-* If you are new to using R, we've [assembled some resources for getting starting with R](../optional-workshop-prep/R-prep.md#pre-workshop-prep-for-r-programming) that can optionally help prepare you for the workshop.
-* Please install the [required software](software-setup.md) and take a look at how we intend to use these platforms during the workshop (see below).
-* Sign up for the **Cancer Data Science** Slack workspace at <http://ccdatalab.org/slack>. Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.
-* Once you have been given your username and temporary password, follow [these instructions](../virtual-setup/rstudio-login.md) to log in to our RStudio server and change your password.
+* Sign up for the **Cancer Data Science** Slack workspace at <http://ccdatalab.org/slack> (Slack installation instructions for [Mac](../virtual-setup/mac-instructions.md), [Windows](../virtual-setup/windows-instructions.md), and [Linux](../virtual-setup/linux-instructions.md)). 
+Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.
+* We will use Slack to distribute your username and temporary password for the RStudio Server we will use during training. 
+Please follow [these instructions](../virtual-setup/rstudio-login.md) to log in to our RStudio server and change your password.
 
-Please take a look at our procedures to familiarize yourself with how we will be using these platforms throughout training:
+## Logistics
 
-* [Zoom procedures](../virtual-setup/zoom-procedures.md)
-* [Slack procedures](../virtual-setup/slack-procedures.md)
+Please review the [Participant Information](participant_information.md) page for information about the workshop location (including nearby lodging), travel reimbursement, and health and safety.
 
 ## Schedule
 
 <!-- Introduce general schedule here -->
 
-**For more details on the schedule for each day, [click here](SCHEDULE.md).**
+This three day in-person workshop workshop will introduce participants to advanced topics in the analysis of single-cell RNA-seq data through a mix of instruction, self-guided exercises, and time to apply what you'll learn to your own data.
 
-## Workshop Structure
+**Please review [the schedule](SCHEDULE.md) for a more detailed view of each day.**
 
-A description of our plans and goals for the workshop can be found on the [Workshop Structure document](workshop-structure.md). Please also refer to the [schedule](SCHEDULE.md) for information about timing and links relevant to each day.
-An overview of the modules we will cover and associated links can be found on the [Workshop Materials document](workshop-materials.md).
-
-During instruction sessions, CCDL staff will lead you through course material using [Zoom](../virtual-setup/zoom-procedures.md), [Slack](../virtual-setup/slack-procedures.md), and [RStudio Server](../virtual-setup/rstudio-login.md).
-We will record instruction and provide it to workshop attendees so they can revisit it outside of workshop hours or in case they experience disruptions during live instruction.
-
-During [consultation sessions](resources-for-consultation-sessions.md), CCDL staff will be available to answer questions and provide 1:1 assistance as you work through exercise notebooks we provide or work with your own transcriptomic data.
-We’ll use Zoom and Slack for these days, too.
-
-We recommend you follow these [guidelines for posting errors](posting-errors-guidelines.md) so you can maximize others' abilities to help you resolve your error.

--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -21,6 +21,9 @@ Please use your full name in your profile, so we can find you easily and add you
 * We will use Slack to distribute your username and temporary password for the RStudio Server we will use during training. 
 Please follow [these instructions](../virtual-setup/rstudio-login.md) to log in to our RStudio server and change your password.
 
+Please contact us at {{site.email}} with any questions ahead of the workshop.
+Alternatively, you are welcome to post any questions you have in the private meeting channel on Slack once you have access.
+
 ## Logistics
 
 Please review the [Participant Information](participant_information.md) page for information about the workshop location (including nearby lodging), travel reimbursement, and health and safety.


### PR DESCRIPTION
Closes #16 - quoting here:

> Remove:
> 
> * Reference to resources for getting started with R
> * Reference to installing required software
> * Reference to Zoom and Slack procedures
> * The workshop structure section -- it should be sufficient to link to the schedule for an in-person workshop in my opinion
> 
> Add:
> 
> * Links to individual operating systems instructions for installing Slack in the bullet point for Cancer Data Science Slack. 
> * Links to logistics.

