### PR TITLE
Slack procedures refresh + link to error posting guidelines

### DIFF
--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -4,7 +4,7 @@ title: Using Slack for CCDL virtual workshops
 
 
 <img style = "padding: 0px 15px 0px 0px; float: left;" src = "screenshots/slack-cancer-data-science-logo.png" width = "75">
-Specifically, we use the **Cancer Data Science Slack** team administered by the Data Lab.
+We use the **Cancer Data Science Slack** team administered by the Data Lab.
 You can join Cancer Data Science Slack by following this link: [ccdatalab.org/slack](https://www.ccdatalab.org/slack)
 
 
@@ -22,40 +22,23 @@ We have instructions for setting up Slack for your operating system available.
 
 - [How we use Slack during workshops](#how-we-use-slack-during-workshops)
   - [Using the training-specific channel](#using-the-training-specific-channel)
-    - [Introduce yourself!](#introduce-yourself)
-    - [General use](#general-use)
-    - [Collecting feedback](#collecting-feedback)
-  - [Using Slack calling during training](#using-slack-calling-during-training)
   - [Using direct messages during training](#using-direct-messages-during-training)
+- [After the workshop](#after-the-workshop)
 - [General Slack use](#general-slack-use)
     - [Attaching a file or image](#attaching-a-file-or-image)
     - [Adding code blocks to messages](#adding-code-blocks-to-messages)
+
 
 ## How we use Slack during workshops
 
 Course instructors will add you to a private channel specific to your training a few days before the start of your training workshop.
 
-If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a CCDL staff member (`Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
+If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a CCDL staff member (`Stephanie Spielman`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
 
 ### Using the training-specific channel
 
-#### Introduce yourself!
-
-When you are added to the training-specific channel, please introduce yourself to others by messaging the channel with the following:
-
-* Your name
-* Your institution and position
-* A brief summary of your research interests and what you are hoping to learn during training
-
-#### General use
-
-You can use the training-specific private channel to do the following:
-
-* Post questions during lectures
-* Post errors and get help with debugging
-* Treat the channel as a study group – if you get stuck on an exercise notebook or your own data, post something so other participants and instructors can help you.
-
-If you have a question, it's very likely someone else in the course has the same question!
+You can use the training-specific private channel to post errors and get help with debugging during the workshop.
+If you have a question, it's very likely someone else in the course has the same question! 
 
 **Responses to questions should be in [threads](https://slack.com/help/articles/115000769927-Use-threads-to-organize-discussions-) as much as possible**, including any screenshots or images.
 To start a thread, hover over the message you want to respond to and click the start a thread icon that appears on the top right of the message:
@@ -65,48 +48,29 @@ To start a thread, hover over the message you want to respond to and click the s
 You can then enter your response in the thread sidebar that appears on the right side of the Slack interface.
 In general, you do not want to check the box that sends the message to the entire channel.
 
-#### Collecting feedback
+For more tips on posting questions about errors you encounter, please see [our guidelines for posting errors to Slack](../workshop/posting-errors-guidelines.md).
 
-We also use the training-specific private channel to poll participants via [Polly](https://www.polly.ai/slack-poll). We collect the following feedback anonymously:
-
-* The most difficult or confusing point of the module ("muddiest point"), which is posted anonymously to the channel
-* What you liked about the module (anonymous, only instructors will see your answer)
-* How we can improve the module (anonymous, only instructors will see your answer)
-
-Use the `Submit Response` button in a Polly message to enter your feedback:
-
-<img src = "screenshots/slack-polly-response.png" width = "600">
-
-### Using Slack calling during training
-
-If you need help during consultation session, a course instructor may initiate a [Slack call](https://slack.com/help/articles/216771908-Make-calls-in-Slack).
-To answer a Slack call, hit the button with the phone icon on the prompt.
-
-<img src = "screenshots/slack-call-prompt.png" height = "300">
-
-_Note: Where possible please utilize headphones throughout the training workshop to minimize audio feedback._
-
-<!--
-Your instructor will ask you to [share your screen](https://slack.com/help/articles/115003501303-Share-your-screen-with-Slack-Calls) using the share your screen icon circled in yellow below.
-It is located at the bottom middle of your Slack call window.
-
-<img src = "screenshots/slack-call-control.png" width = "300">
-
-When you share your screen in Slack, please note that the **entire screen** will be displayed.
-You can not select a specific window to share.
--->
+**Your instructors may also use the Slack channel to clarify or expand upon questions that came up during the course of the workshop.**
 
 ### Using direct messages during training
 
-If you have a question that is **_highly specific_** to your own data or a problem with your RStudio credentials, you may [direct message](https://slack.com/help/articles/212281468-What-is-a-direct-message) a CCDL staff member.
+If you have a question that is **_highly specific_** to your own data, a problem with your RStudio credentials, or encounter issues with locating the room for training, you may [direct message](https://slack.com/help/articles/212281468-What-is-a-direct-message) a CCDL staff member.
 
 First, use the new message button in the top right side corner of the Slack interface.
 
 <img src = "screenshots/slack-compose-new-message.png" width="300">
 
-You are then able to search for the CCDL instructors – `Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro` – and compose your message.
+You are then able to search for the CCDL instructors – `Stephanie Spielman`, `Ally Hawkins`, `Jen O'Malley`, `Josh Shapiro`, or `Jaclyn Taroni` – and compose your message.
 
 Course instructors may direct you to the training-specific channel for more general questions or to another instructor where appropriate.
+
+## After the workshop
+
+After the workshop, you'll have access to the training-specific private channel indefinitely. 
+Please note that messages will only be retained for 90 days (a limitation of the Slack plan we use).
+
+Your instruction team will use the channel to hold office hours and announce other consultation opportunities in the future.
+
 
 ## General Slack use
 

--- a/working-with-your-data/working-with-your-own-data.md
+++ b/working-with-your-data/working-with-your-own-data.md
@@ -17,7 +17,8 @@ This guide will take you through how to get your data onto our RStudio server so
 - You will have access to our RStudio Server for 6 months.
 We will email you with a reminder 6 months from now so you can make sure to remove any files from our RStudio Server that you may find useful before your access is revoked and the files are deleted.
 
-- As always, please Slack one of the CCDL team members if you need help with anything (that is what we are here for!).
+- As always, please reach out to one of the CCDL team members if you need help with anything (that is what we are here for!).
+
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -41,6 +42,7 @@ We will email you with a reminder 6 months from now so you can make sure to remo
     - [install.packages()](#installpackages)
     - [Bioconductor packages](#bioconductor-packages)
   - [More resources on package installation strategies](#more-resources-on-package-installation-strategies)
+- [Posting errors to Slack](#posting-errors-to-slack)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -439,3 +441,9 @@ Or if it failed to install, it will give you a `non-zero exit status` message.
 - [Stack Overflow: Non-zero exit status](https://stackoverflow.com/questions/35666638/cant-access-user-library-in-r-non-zero-exit-status-warning)
 - [Installing R packages](https://www.r-bloggers.com/installing-r-packages/)
 - [Installing GitHub R Packages](https://cran.r-project.org/web/packages/githubinstall/vignettes/githubinstall.html)
+
+
+## Posting errors to Slack
+
+If you are working with your own data outside of instruction hours or after the workshop and encounter errors, we encourage you to use the training-specific private Slack channel to ask for help.
+Please review the tips in [our guidelines for posting errors to Slack](posting-errors-guidelines.md).

--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -18,6 +18,7 @@ Dates: {{site.start_date}} through {{site.end_date}}
 * Please review the [Code of Conduct](../code-of-conduct.md).
 * Sign up for the **Cancer Data Science** Slack workspace at <http://ccdatalab.org/slack> (Slack installation instructions for [Mac](../virtual-setup/mac-instructions.md), [Windows](../virtual-setup/windows-instructions.md), and [Linux](../virtual-setup/linux-instructions.md)). 
 Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.
+You can find more information about how we'll use Slack [here](../virtual-setup/slack-procedures.md).
 * We will use Slack to distribute your username and temporary password for the RStudio Server we will use during training. 
 Please follow [these instructions](../virtual-setup/rstudio-login.md) to log in to our RStudio server and change your password.
 

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -8,6 +8,8 @@ You can review instruction materials, work through exercise notebooks we provide
 On this page, we've assembled some resources you may find helpful during these sessions. 
 
 If you're working with your own data or practice data outside of instruction hours and encounter errors, please feel free to post them in the training-specific Slack channel for your instructors to review at the next session (please see [these guidelines](posting-errors-guidelines.md) for tips on posting errors to Slack).
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 **Table of contents**
 
@@ -26,7 +28,8 @@ If you're working with your own data or practice data outside of instruction hou
   - [_Mus musculus_](#_mus-musculus_)
   - [_Danio rerio_](#_danio-rerio_)
   - [_Canis lupus familiaris_](#_canis-lupus-familiaris_)
- 
+  
+ <!-- END doctoc generated TOC please keep comment here to allow auto update -->
  
 ## Working with your own data on RStudio Server
 

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -1,8 +1,18 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
+---
+title: Resources for Consultation Sessions
+nav_title: Resources
+---
 
-- [Module cheatsheets](#module-cheatsheets)
+Our consultation sessions are designed for you to spend your time as you would like with the support of your instructors.
+
+You can review instruction materials, work through exercise notebooks we provide, or analyze your own data.
+
+On this page, we've assembled some resources you may find helpful during these sessions. For more information about the structure of consultation sessions and how to get help, please review [the Consultation sessions section of the Workshop Structure page](workshop-structure.md#consultation-sessions).
+
+If you're working with your own data or practice data outside of instruction hours and encounter errors, please feel free to  
+
+**Table of contents**
+
 - [Working with your own data on RStudio Server](#working-with-your-own-data-on-rstudio-server)
 - [Obtaining practice datasets](#obtaining-practice-datasets)
   - [refine.bio](#refinebio)
@@ -18,37 +28,8 @@
   - [_Mus musculus_](#_mus-musculus_)
   - [_Danio rerio_](#_danio-rerio_)
   - [_Canis lupus familiaris_](#_canis-lupus-familiaris_)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
----
-title: Resources for Consultation Sessions
-nav_title: Resources
----
-
-Our consultation sessions are designed for you to spend your time as you would like with the support of your instructors.
-
-You can review instruction materials, work through exercise notebooks we provide, or analyze your own data.
-
-On this page, we've assembled some resources you may find helpful during these sessions. For more information about the structure of consultation sessions and how to get help, please review [the Consultation sessions section of the Workshop Structure page](workshop-structure.md#consultation-sessions).
-
-**Table of contents**
-
-- [Working with your own data on RStudio Server](#working-with-your-own-data-on-rstudio-server)
-- [Obtaining practice datasets](#obtaining-practice-datasets)
-  - [refine.bio](#refinebio)
-    - [Bulk RNA-seq data on refine.bio](#bulk-rna-seq-data-on-refinebio)
-  - [Single-cell RNA-seq data](#single-cell-rna-seq-data)
-    - [_Tabula Muris_ data](#tabula-muris-data)
-    - [Human Cell Atlas data](#human-cell-atlas-data)
-    - [Reading `loom` format data in R](#reading-loom-format-data-in-r)
-- [Transcriptome indices for common organisms](#transcriptome-indices-for-common-organisms)
-  - [_Homo sapiens_](#homo-sapiens)
-  - [_Mus musculus_](#mus-musculus)
-  - [_Danio rerio_](#danio-rerio)
-  - [_Canis lupus familiaris_](#canis-lupus-familiaris)
-
-
+ 
+ 
 ## Working with your own data on RStudio Server
 
 If you plan on working with your own data during consultations, you may find it helpful to leverage our RStudio Server.

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -34,7 +34,6 @@ On this page, we've assembled some resources you may find helpful during these s
 
 **Table of contents**
 
-- [Module cheatsheets](#module-cheatsheets)
 - [Working with your own data on RStudio Server](#working-with-your-own-data-on-rstudio-server)
 - [Obtaining practice datasets](#obtaining-practice-datasets)
   - [refine.bio](#refinebio)
@@ -49,14 +48,6 @@ On this page, we've assembled some resources you may find helpful during these s
   - [_Danio rerio_](#danio-rerio)
   - [_Canis lupus familiaris_](#canis-lupus-familiaris)
 
-## Module cheatsheets
-
-The [`modules-cheatsheets` directory](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/module-cheatsheets) of our [GitHub repository of training materials](https://github.com/AlexsLemonade/training-modules) contains Markdown and PDF version of "cheatsheets" that contain tables with short descriptions of functions used throughout training modules and links to documentation.
-
-* Introduction to R/Tidyverse cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release_tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.pdf))
-* RNA-seq module cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/module-cheatsheets/RNA-seq-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release_tag}}/module-cheatsheets/RNA-seq-cheatsheet.pdf))
-
-You may find these helpful as you review instruction material or work through exercise notebooks.
 
 ## Working with your own data on RStudio Server
 

--- a/workshop/resources-for-consultation-sessions.md
+++ b/workshop/resources-for-consultation-sessions.md
@@ -4,12 +4,10 @@ nav_title: Resources
 ---
 
 Our consultation sessions are designed for you to spend your time as you would like with the support of your instructors.
-
 You can review instruction materials, work through exercise notebooks we provide, or analyze your own data.
+On this page, we've assembled some resources you may find helpful during these sessions. 
 
-On this page, we've assembled some resources you may find helpful during these sessions. For more information about the structure of consultation sessions and how to get help, please review [the Consultation sessions section of the Workshop Structure page](workshop-structure.md#consultation-sessions).
-
-If you're working with your own data or practice data outside of instruction hours and encounter errors, please feel free to  
+If you're working with your own data or practice data outside of instruction hours and encounter errors, please feel free to post them in the training-specific Slack channel for your instructors to review at the next session (please see [these guidelines](posting-errors-guidelines.md) for tips on posting errors to Slack).
 
 **Table of contents**
 


### PR DESCRIPTION
Closes #19. In addition to adding links as described in https://github.com/AlexsLemonade/2023-january-training/issues/19#issuecomment-1385831512, I am:

* Refreshing the Slack procedures to be more relevant for this workshop 
* Adding a link to those Slack procedures in the home page
* De-duped the table of contents in the consultation sessions page
* Removed reference to the module cheatsheets (we don't have those for this one AFAIK!) in the consultation sessions page while I was there