### PR TITLE
Update docker tag info in config file

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -13,8 +13,8 @@ end_date: 2023-02-02
 release_tag: master
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
-docker_repo: DOCKER-REPOSITORY
-docker_tag: DOCKER-TAG
+docker_repo: training_rnaseq
+docker_tag: 2023-january
 
 # Theme and theme options
 theme: minima


### PR DESCRIPTION
Closes https://github.com/AlexsLemonade/training-admin/issues/796

This PR updates the docker repo and tag information in this repository's `_config.yaml` as to finish addressing issue #796 in the training-admin repo.

Per that issue, I have confirmed that the docker image was successfully tagged `2023-january` for the upcoming training.